### PR TITLE
test(setting): Test-only PR demonstrating security vulnerability

### DIFF
--- a/web/modules/custom/my_testing_module/tests/src/Functional/MyFunctionalTest.php
+++ b/web/modules/custom/my_testing_module/tests/src/Functional/MyFunctionalTest.php
@@ -48,4 +48,14 @@ class MyFunctionalTest extends BrowserTestBase {
     $assert->pageTextContains('Hi Regular User.');
   }
 
+  /**
+   * Confirm settings form is not accessible to unauthenticated users.
+   */
+  public function testSettingsFormIsNotAccessibleToUnauthenticatedUsers() {
+    $assert = $this->assertSession();
+    $this->drupalGet('admin/config/system/my_testing_module/settings');
+    $assert->pageTextContains('You are not authorized to access this page.');
+    $assert->statusCodeEquals(403);
+  }
+
 }


### PR DESCRIPTION
This PR uses a test-only to demonstrate a security vulnerability. 

We should get a 403 status code when we access the form, but we're actually allowed to proceed. 

This test provides clearly reproducible steps for replicating the bug, which is helpful to project maintainers to know how to understand the problem.