### PR TITLE
fix(setting): Fix permission issue with settings form

### DIFF
--- a/web/modules/custom/my_testing_module/my_testing_module.permissions.yml
+++ b/web/modules/custom/my_testing_module/my_testing_module.permissions.yml
@@ -2,3 +2,6 @@ my super secret privilege:
   title: 'My Super Secret Privilege'
 yet another privilege:
   title: 'Yet Another Privilege'
+edit my admin form:
+  title: 'Edit my admin form'
+  description: 'Allow users to edit my admin form'

--- a/web/modules/custom/my_testing_module/my_testing_module.routing.yml
+++ b/web/modules/custom/my_testing_module/my_testing_module.routing.yml
@@ -12,6 +12,6 @@ my_testing_module.settings:
     _form: '\Drupal\my_testing_module\Form\MySettingsForm'
     _title: 'My Testing Module Settings'
   requirements:
-    _permission: 'access content'
+    _permission: 'edit my admin form'
   options:
     _admin_route: TRUE

--- a/web/modules/custom/my_testing_module/tests/src/Functional/MyFunctionalTest.php
+++ b/web/modules/custom/my_testing_module/tests/src/Functional/MyFunctionalTest.php
@@ -24,6 +24,13 @@ class MyFunctionalTest extends BrowserTestBase {
   protected $authorizedUser;
 
   /**
+   * Logged in user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $authorizedFormUser;
+
+  /**
    * {@inheritdoc}
    */
   public static $modules = [
@@ -36,6 +43,7 @@ class MyFunctionalTest extends BrowserTestBase {
   protected function setUp() {
     parent::setUp();
     $this->authorizedUser = $this->drupalCreateUser([], 'Regular User');
+    $this->authorizedFormUser = $this->drupalCreateUser(['edit my admin form'], 'Form User');
   }
 
   /**
@@ -56,6 +64,28 @@ class MyFunctionalTest extends BrowserTestBase {
     $this->drupalGet('admin/config/system/my_testing_module/settings');
     $assert->pageTextContains('You are not authorized to access this page.');
     $assert->statusCodeEquals(403);
+  }
+
+  /**
+   * Confirm settings form is not accessible for unauthorized users.
+   */
+  public function testSettingsFormIsNotAccessibleToUnauthorizedUsers() {
+    $assert = $this->assertSession();
+    $this->drupalLogin($this->authorizedUser);
+    $this->drupalGet('admin/config/system/my_testing_module/settings');
+    $assert->pageTextContains('You are not authorized to access this page.');
+    $assert->statusCodeEquals(403);
+  }
+
+  /**
+   * Confirm settings form is accessible for authorized users.
+   */
+  public function testSettingsFormIsAccessibleToAuthorizedUsers() {
+    $assert = $this->assertSession();
+    $this->drupalLogin($this->authorizedFormUser);
+    $this->drupalGet('admin/config/system/my_testing_module/settings');
+    $assert->pageTextNotContains('You are not authorized to access this page.');
+    $assert->statusCodeEquals(200);
   }
 
 }

--- a/web/modules/custom/my_testing_module/tests/src/Functional/MyFunctionalTest.php
+++ b/web/modules/custom/my_testing_module/tests/src/Functional/MyFunctionalTest.php
@@ -48,4 +48,14 @@ class MyFunctionalTest extends BrowserTestBase {
     $assert->pageTextContains('Hi Regular User.');
   }
 
+  /**
+   * Confirm settings form is not accessible to unauthenticated users.
+   */
+  public function testSettingsFormIsNotAccessibleToUnauthenticatedUsers() {
+    $assert = $this->assertSession();
+    $this->drupalGet('admin/config/system/my_testing_module/settings');
+    $assert->pageTextContains('You are not authorized to access this page.');
+    $assert->statusCodeEquals(403);
+  }
+
 }


### PR DESCRIPTION
This PR takes the test from #4 and then fixes the bug.  Furthermore, we add two additional test cases.

These are important as they help confirm not only are unauthorized users blocked, but that only users with the desired permission have access.